### PR TITLE
Fix allow contract caller

### DIFF
--- a/contracts/decent-delegate.clar
+++ b/contracts/decent-delegate.clar
@@ -641,7 +641,7 @@
                                   { sender: tx-sender, contract-caller: contract-caller })
                         false)))
           ;; is the caller allowance expired?
-          (if (< burn-block-height (unwrap! (get until-burn-ht caller-allowed) true))
+          (if (> burn-block-height (unwrap! (get until-burn-ht caller-allowed) true))
               false
               true))))
 


### PR DESCRIPTION
This PR
* fixes the until-burn-ht used in `allow-contract-caller`